### PR TITLE
Tutorial-button now links to the new Documentation (2.0)

### DIFF
--- a/Resources/Views/home.leaf
+++ b/Resources/Views/home.leaf
@@ -48,7 +48,7 @@
 
                 <div class="action">
                     <a href="https://vapor.github.io/documentation/getting-started/install-swift-3-macos.html" class="button swift">Install</a>
-                    <a href="https://vapor.github.io/documentation/getting-started/hello-world.html" class="button tutorial">Tutorial</a>
+                    <a href="https://docs.vapor.codes/2.0/getting-started/hello-world/" class="button tutorial">Tutorial</a>
                 </div>
 
                 <div class="window">


### PR DESCRIPTION
The tutorial-button links to the old documentation whereas the docs-link in the menu gets you to the new documentation (2.0)
This pull-request updates the tutorial-button to link to the same documentation (2.0) as the docs-link in the navigation does.