### PR TITLE
Fix a typo in the "Get Started" link

### DIFF
--- a/src/vapor/common/callToAction.vue
+++ b/src/vapor/common/callToAction.vue
@@ -42,7 +42,7 @@
         data() {
             return {
                 buttons: [
-                    { id: 'start', text: 'Get Started', url: 'https://docs.vapor.codes/3.0/install/macros' },
+                    { id: 'start', text: 'Get Started', url: 'https://docs.vapor.codes/3.0/install/macos/' },
                     { id: 'community', text: 'Join Chat', url: 'https://discord.gg/vapor' }
                 ]
             }


### PR DESCRIPTION
Fix a a typo in the "Get Started" link on the home page that @AxelCB spotted. :+1: