### PR TITLE
Fix typos

### DIFF
--- a/src/i18n/fr.js
+++ b/src/i18n/fr.js
@@ -20,7 +20,7 @@ export default {
       title: 'Contribuer !',
       options: {
           code: {
-              description: 'Contribuez le développement sur Github !'
+              description: 'Contribuez au développement sur Github !'
           },
           chat: {
               title: 'Discuter',
@@ -28,7 +28,7 @@ export default {
           },
           donate: {
               title: 'Soyez donateur',
-              description: 'Faites une donation unique ou récurrente pour aider au développement.'
+              description: 'Faites une donation unique ou récurrente pour aider le développement.'
           }
       }
   },

--- a/src/i18n/fr.js
+++ b/src/i18n/fr.js
@@ -3,7 +3,7 @@ export default {
       slogan: 'Le futur du développement web'
   },
   callToAction: {
-      start: 'Premiers pas',
+      start: 'Premier pas',
       join: 'Discuter'
   },
   nav: {

--- a/src/i18n/fr.js
+++ b/src/i18n/fr.js
@@ -3,7 +3,7 @@ export default {
       slogan: 'Le futur du développement web'
   },
   callToAction: {
-      start: 'Premier pas',
+      start: 'Premiers pas',
       join: 'Discuter'
   },
   nav: {
@@ -12,8 +12,8 @@ export default {
       docs: 'Docs'
   },
   bio: {
-      first: '<a target="_blank" href="https://medium.com/@codevapor/vapor-3-0-0-released-8356fa619a5d">Ultra-rapide</a>, asynchrone, architecture orientée événements et propulsé par <a target="_blank" href="https://github.com/apple/swift-nio">Apple\'s SwiftNIO</a>.',
-      second: 'Écris intégralement en <a target="_blank" href="https://swift.org">Swift</a>, aussi puissant que rapide à apprendre.',
+      first: '<a target="_blank" href="https://medium.com/@codevapor/vapor-3-0-0-released-8356fa619a5d">Ultra-rapide</a>, asynchrone, architecture orientée évènements et propulsé par <a target="_blank" href="https://github.com/apple/swift-nio">Apple\'s SwiftNIO</a>.',
+      second: 'Écrit intégralement en <a target="_blank" href="https://swift.org">Swift</a>, aussi puissant que rapide à apprendre.',
       third: 'Expressif, <a target="_blank" href="https://developer.apple.com/videos/play/wwdc2015/408/"><i>protocol-oriented</i></a>, fortement typé et facilement maintenable.'
   },
   contribute: {
@@ -28,7 +28,7 @@ export default {
           },
           donate: {
               title: 'Soyez donateur',
-              description: 'Faites une donation unique ou récurrente pour aider le développement.'
+              description: 'Faites une donation unique ou récurrente pour aider au développement.'
           }
       }
   },

--- a/src/i18n/fr.js
+++ b/src/i18n/fr.js
@@ -20,7 +20,7 @@ export default {
       title: 'Contribuer !',
       options: {
           code: {
-              description: 'Contribuez au développement sur Github !'
+              description: 'Contribuez le développement sur Github !'
           },
           chat: {
               title: 'Discuter',


### PR DESCRIPTION
Fixes typos. One of the words is actually right: "événements" vs "évènements", but the latter is what's officially recommended by the _Académie Française_.