### PR TITLE
Fix "Join our Discord" button link

### DIFF
--- a/Sources/Website/HomePage.swift
+++ b/Sources/Website/HomePage.swift
@@ -338,7 +338,7 @@ extension HomePage {
                                 Text("Vapor's 13k+ Discord community will be at your side to support you along the way. Ask questions, contribute and be a part of a thriving, wholesome corner of the internet.")
                             }
                             Button {
-                                Link(url: "https://docs.vapor.codes/") {
+                                Link(url: "https://vapor.team/") {
                                     Text("Join our Discord")
                                 }.linkTarget(.blank)
                             }.class("btn btn-primary w-mobile-100")


### PR DESCRIPTION
When I clicked the "Join our Discord" button in the homepage, it took me to the docs site (https://docs.vapor.codes), where I had to search there for the Discord link.

This PR sets the link there to (what I assume is) the correct one: https://vapor.team

![Arc-2024-11-08-12 54 39@2x](https://github.com/user-attachments/assets/0fd6be95-5360-401f-9f90-0422c46ef313)
